### PR TITLE
fix: close the child process

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -235,6 +235,9 @@ async function runNirCmd(args: Array<string>): Promise<number> {
         stderr: "piped"
     });
     const { code } = await p.status()
+    p.stdout.close();
+    p.stderr.close();
+    p.close();
     return code;
 }
 
@@ -253,6 +256,9 @@ async function runCmdmp3(mp3: string): Promise<number> {
         stderr: "piped"
     });
     const { code } = await p.status()
+    p.stdout.close();
+    p.stderr.close();
+    p.close();
     return code;
 }
 


### PR DESCRIPTION
Not closing the process causes:

```
error: AssertionError: Test case is leaking 3 resources:

 - A child process stdout (rid 3) was opened during the test, but not closed during the test. Close the child process stdout by calling `proc.stdout.close()`.      
 - A child process stderr (rid 4) was opened during the test, but not closed during the test. Close the child process stderr by calling `proc.stderr.close()`.      
 - A child process (rid 5) was started during the test, but not closed during the test. Close the child process by calling `proc.kill()` or `proc.close()`.

    at assert (deno:ext/web/00_infra.js:294:13)
    at resourceSanitizer (deno:runtime/js/40_testing.js:407:7)
    at async Object.exitSanitizer [as fn] (deno:runtime/js/40_testing.js:425:9)
    at async runTest (deno:runtime/js/40_testing.js:831:7)
    at async Object.runTests (deno:runtime/js/40_testing.js:1084:22)
```

...when testing code that uses the library.